### PR TITLE
Update for schools images

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -407,9 +407,12 @@ input[type=file]::file-selector-button {
   display: inline-block;
 }
 
+#school_icons td {
+	text-align: center !important;
+}
+
 #school_icons img{
-  width: 100px;
-  height: 100px;
+  max-width: 120px;
 }
 
 #school_media img{

--- a/school_details.php
+++ b/school_details.php
@@ -63,10 +63,11 @@
   $status = $row['status'];
   $notes = $row['notes'];
 
+  $time = time();
   echo "<h3> School Details </h3>
 	  <div id=\"school_icons\" class=\"school_icon\">";
 			$profile_image = get_profile_image($School_Id); 
-			echo "			<img src=\"$profile_image\" alt=\"school image\">
+			echo "			<img src=\"$profile_image?v=$time\" alt=\"school image\">
 	  </div>
 	  <br>
       <div id= \"container_2\" class=\"school_details\">

--- a/schools.php
+++ b/schools.php
@@ -50,6 +50,7 @@
 			$counter = 0;  
 			// Create table with data from each row
             while($row = $result->fetch_assoc()) {
+				$time = time();
 				$counter++;
 				if($counter == 0) {
 					echo "<tr>";
@@ -59,7 +60,7 @@
 				echo  "<td class=\"school_icon\">
 							<a href=\"school_details.php?School_Id=$id&target=_blank\">";
 				$profile_image = get_profile_image($id); 
-				echo "			<img src=\"$profile_image\" alt=\"school image\"><br><label>$id</label>
+				echo "			<img src=\"$profile_image?v=$time\" alt=\"school image\"><br><label>$id</label>
 							</a>
 						</td>";
 				if($counter % 5 == 0 && $counter > 0) {


### PR DESCRIPTION
css/main.css:
-- align the image and the text in the center of the table cell -- set max-width on school icons to 120px, does not set height.  Keeps rectangular images rectangular and keeps the columns lines up vertically when tiling the schools.
school_details.php:
-- added a time stamp for the img src so changing the profile image will always display the latest change even if the old file and the new file have the same extension
schools.php:
-- added a time stamp for the img src so changing the profile image will always display the latest change even if the old file and the new file have the same extension